### PR TITLE
setup.sh installs binaries and cluster tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 config.yaml
+bin/
+setup/vendir/

--- a/config-REDACTED.yaml
+++ b/config-REDACTED.yaml
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#@data/values
 ---
 registry:
   server: https://index.docker.io/v1/
@@ -22,14 +21,14 @@ registry:
 service_account_name: default
 image_prefix: ellinj/demo-
 
-cartographer:
-  cert_manager_version: 1.5.3
-  secretgen_controller_version: 0.6.0
-  cartographer_version: v0.0.8-rc.7
-  source_controller_version: 0.17.0
+#cartographer:
+#  cert_manager_version: 1.5.3
+#  secretgen_controller_version: 0.6.0
+#  cartographer_version: v0.0.8-rc.7
+#  source_controller_version: 0.17.0
 
 kpack:
-  version: 0.4.3
+#  version: 0.4.3
   # credentials for the container registry you'll be using to store images
   builder:
     # path to the container repository where kpack build artifacts are stored
@@ -50,3 +49,18 @@ envoy:
 domain:
   name: 127-0-0-1.nip.io
   type: real
+
+##################################################
+##### vendir configuration
+##################################################
+
+vendir:
+  # To get latest versions available, use: getLatest: true
+  # To get versions specified in vendir.yml, use: getLatest: ""
+  getLatest: ""
+  # For installation of CLI binaries
+  host:
+    # os: darwin, linux, windows (default specified in vendir.yml)
+    os: ""
+    # arch: amd64, etc (default specified in vendir.yml)
+    arch: ""

--- a/config-REDACTED.yaml
+++ b/config-REDACTED.yaml
@@ -54,10 +54,23 @@ domain:
 ##### vendir configuration
 ##################################################
 
+# Vendir configuration
 vendir:
-  # To get latest versions available, use: getLatest: true
-  # To get versions specified in vendir.yml, use: getLatest: ""
+  # getLatest overrides declared versions (disable using getLatest: "")
   getLatest: ""
+  versions:
+    cert-manager: 1.5.3
+    secretgen-controller: 0.6.0
+    cartographer: 0.0.8-rc.7
+    flux2: 0.24.1
+    kpack: 0.4.3
+    yq: 4.16.1
+    ytt: 0.38.0
+    kapp: 0.43.0
+    kn: 1.1.0
+    tce: 0.9.1
+    kp: 0.4.2
+    kubectl: 1.23.1
   # For installation of CLI binaries
   host:
     # os: darwin, linux, windows (default specified in vendir.yml)

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# shellcheck disable=SC2155
+#readonly DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Download installation files
+#VENDIR_GITHUB_API_TOKEN=<your-github-token> \
+ytt -f setup/vendir.yml \
+  --data-values-file setup/values.yaml \
+  --data-values-file config.yaml \
+  | vendir sync --chdir setup -f-
+
+# Make binaries executable and put them in the PATH
+mkdir -p bin
+find setup/vendir/binaries -type f -exec cp {} bin \;
+for f in bin/*; do newf=$(basename "$f") && mv "$f" bin/"${newf%%-*}"; done
+for f in bin/*; do newf=$(basename "$f") && mv "$f" bin/"${newf%%_*}"; done
+chmod +x bin/*
+BINDIR="${PWD}"/bin
+PATH="${BINDIR}":"${PATH}"
+
+# Install credentials/RBAC
+ytt -f setup/access-control \
+    --data-values-file config.yaml \
+    | kapp deploy -a access-control -f- --yes
+
+# Install tools (with overlays, where appropriate)
+ytt -f setup/vendir/cartographer \
+    -f setup/overlays/cartographer \
+    --data-values-file config.yaml \
+    | kapp deploy -a cartographer -f- --yes
+
+ytt -f setup/vendir/cert-manager \
+    --data-values-file config.yaml \
+    | kapp deploy -a cert-manager -f- --yes
+
+ytt -f setup/vendir/secretgen-controller \
+    --data-values-file config.yaml \
+    | kapp deploy -a secretgen-controller -f- --yes
+
+ytt -f setup/vendir/flux2 \
+    --data-values-file config.yaml \
+    | kapp deploy -a flux2 -f- --yes
+
+ytt -f setup/vendir/kpack \
+    --data-values-file config.yaml \
+    | kapp deploy -a kpack -f- --yes

--- a/setup/access-control/supplychain-access.yaml
+++ b/setup/access-control/supplychain-access.yaml
@@ -1,0 +1,23 @@
+#@ load("@ytt:data", "data")
+#@ load("@ytt:json", "json")
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: registry-credentials
+type: kubernetes.io/dockerconfigjson
+stringData:
+  #@ registry_creds = {"username": data.values.registry.username, "password": data.values.registry.password}
+  .dockerconfigjson: #@ json.encode({"auths": {data.values.registry.server: registry_creds}})
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: service-account
+#@ if data.values.registry.password != "":
+secrets:
+  - name: registry-credentials
+imagePullSecrets:
+  - name: registry-credentials
+#@ end

--- a/setup/access-control/values.yaml
+++ b/setup/access-control/values.yaml
@@ -1,0 +1,13 @@
+#@data/values
+
+#! This file is intended to specify default values. To override, use
+#! a separate values file (ytt ---data-values-file my-values.yaml ...)
+
+---
+registry:
+  server: https://index.docker.io/v1/
+  username:
+  password:
+
+workload:
+  namespace: default

--- a/setup/access-control/workload-access.yaml
+++ b/setup/access-control/workload-access.yaml
@@ -51,6 +51,7 @@ rules:
       - taskruns
       - deployments
       - services
+      - configmaps
       - ingresses
     verbs:
       - get

--- a/setup/access-control/workload-access.yaml
+++ b/setup/access-control/workload-access.yaml
@@ -1,0 +1,92 @@
+#@ load("@ytt:data", "data")
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: workload-service-account
+  namespace: #@ data.values.workload.namespace
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: workload-role-binding
+  namespace: #@ data.values.workload.namespace
+roleRef:
+  kind: ClusterRole
+  name: workload-cluster-role-namespaced-resources
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: workload-service-account
+    apiGroup: ""
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: workload-cluster-role-namespaced-resources
+rules:
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+      - image.toolkit.fluxcd.io
+      - kpack.io
+      - kapp.k14s.io/v1alpha1
+      - kappctrl.k14s.io
+      - serving.knative.dev/v1
+      - carto.run
+      - tekton.dev
+      - apps
+      - ""
+      - networking.k8s.io
+    resources:
+      - gitrepositories
+      - imagerepositories
+      - imagepolicies
+      - images
+      - configs
+      - apps
+      - services
+      - runnables
+      - tasks
+      - taskruns
+      - deployments
+      - services
+      - ingresses
+    verbs:
+      - list
+      - create
+      - update
+      - delete
+      - patch
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: workload-cluster-role-cluster-resources
+rules:
+  - apiGroups:
+      - tekton.dev
+    resources:
+      - clustertasks
+    verbs:
+      - list
+      - create
+      - update
+      - delete
+      - patch
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: workload-cluster-role-binding
+roleRef:
+  kind: ClusterRole
+  name: workload-cluster-role-cluster-resources
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: workload-service-account
+    apiGroup: ""
+    namespace: #@ data.values.workload.namespace

--- a/setup/access-control/workload-access.yaml
+++ b/setup/access-control/workload-access.yaml
@@ -53,6 +53,7 @@ rules:
       - services
       - ingresses
     verbs:
+      - get
       - list
       - create
       - update

--- a/setup/overlays/cartographer/cartographer.yaml
+++ b/setup/overlays/cartographer/cartographer.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cartographer-system

--- a/setup/values.yaml
+++ b/setup/values.yaml
@@ -2,7 +2,23 @@
 ##### vendir configuration
 ##################################################
 
+# Vendir configuration
 vendir:
+  # getLatest overrides declared versions (disable using getLatest: "")
+  getLatest: ""
+  versions:
+    cert-manager: 1.5.3
+    secretgen-controller: 0.6.0
+    cartographer: 0.0.8-rc.7
+    flux2: 0.24.1
+    kpack: 0.4.3
+    yq: 4.16.1
+    ytt: 0.38.0
+    kapp: 0.43.0
+    kn: 1.1.0
+    tce: 0.9.1
+    kp: 0.4.2
+    kubectl: 1.23.1
   # For installation of CLI binaries
   host:
     # os: darwin, linux, windows (default specified in vendir.yml)

--- a/setup/values.yaml
+++ b/setup/values.yaml
@@ -1,0 +1,11 @@
+##################################################
+##### vendir configuration
+##################################################
+
+vendir:
+  # For installation of CLI binaries
+  host:
+    # os: darwin, linux, windows (default specified in vendir.yml)
+    os: ""
+    # arch: amd64, etc (default specified in vendir.yml)
+    arch: ""

--- a/setup/vendir.lock.yml
+++ b/setup/vendir.lock.yml
@@ -1,0 +1,52 @@
+apiVersion: vendir.k14s.io/v1alpha1
+directories:
+- contents:
+  - githubRelease:
+      url: https://api.github.com/repos/jetstack/cert-manager/releases/48370396
+    path: .
+  path: vendir/cert-manager
+- contents:
+  - githubRelease:
+      url: https://api.github.com/repos/vmware-tanzu/carvel-secretgen-controller/releases/52280448
+    path: .
+  path: vendir/secretgen-controller
+- contents:
+  - githubRelease:
+      url: https://api.github.com/repos/vmware-tanzu/cartographer/releases/54277900
+    path: .
+  path: vendir/cartographer
+- contents:
+  - githubRelease:
+      url: https://api.github.com/repos/fluxcd/flux2/releases/54991712
+    path: .
+  path: vendir/flux2
+- contents:
+  - githubRelease:
+      url: https://api.github.com/repos/pivotal/kpack/releases/53942007
+    path: .
+  path: vendir/kpack
+- contents:
+  - githubRelease:
+      url: https://api.github.com/repos/mikefarah/yq/releases/54620497
+    path: yq
+  - githubRelease:
+      url: https://api.github.com/repos/vmware-tanzu/carvel-ytt/releases/53677754
+    path: ytt
+  - githubRelease:
+      url: https://api.github.com/repos/vmware-tanzu/carvel-kapp/releases/54717304
+    path: kapp
+  - githubRelease:
+      url: https://api.github.com/repos/knative/client/releases/55277647
+    path: kn
+  - githubRelease:
+      url: https://api.github.com/repos/vmware-tanzu/kpack-cli/releases/52946265
+    path: kp
+  - http: {}
+    path: kubectl
+  path: vendir/binaries
+- contents:
+  - githubRelease:
+      url: https://api.github.com/repos/vmware-tanzu/community-edition/releases/50492001
+    path: .
+  path: vendir/binaries-tce
+kind: LockConfig

--- a/setup/vendir.yml
+++ b/setup/vendir.yml
@@ -1,0 +1,156 @@
+#@ load("@ytt:data", "data")
+
+#! For more info on setting semver constraints, see:
+#!   https://carvel.dev/vendir/docs/latest/versions
+#!   https://github.com/blang/semver#ranges
+#@ def getConstraint(key):
+#@   if data.values.vendir.getLatest:
+#@     return ">0.0.0"
+#@   else:
+#@     return versions[key]
+#@   end
+#@ end
+
+#@ versions = {
+#@ "cert-manager": "1.5.3",
+#@ "secretgen-controller": "0.6.0",
+#@ "cartographer": "0.0.8-rc.7",
+#@ "flux2": "0.24.1",
+#@ "kpack": "0.4.3",
+#@ "yq": "4.16.1",
+#@ "ytt": "0.38.0",
+#@ "kapp": "0.43.0",
+#@ "kn": "1.1.0",
+#@ "tce": "0.9.1",
+#@ "kp": "0.4.2",
+#@ "kubectl": "1.23.1",
+#@ }
+
+#@ os = data.values.vendir.host.os or "darwin"
+#@ arch = data.values.vendir.host.arch or "amd64"
+---
+apiVersion: vendir.k14s.io/v1alpha1
+kind: Config
+minimumRequiredVersion: 0.8.0
+directories:
+  #! Product release files
+  - path: vendir/cert-manager
+    contents:
+    - path: .
+      githubRelease:
+        slug: jetstack/cert-manager
+        tagSelection:
+          semver:
+            constraints: #@ getConstraint("cert-manager")
+        assetNames: [ "cert-manager.yaml" ]
+        disableAutoChecksumValidation: true
+  - path: vendir/secretgen-controller
+    contents:
+    - path: .
+      githubRelease:
+        slug: vmware-tanzu/carvel-secretgen-controller
+        tagSelection:
+          semver:
+            constraints: #@ getConstraint("secretgen-controller")
+        assetNames: ["release.yml"]
+        disableAutoChecksumValidation: true
+  - path: vendir/cartographer
+    contents:
+    - path: .
+      githubRelease:
+        slug: vmware-tanzu/cartographer
+        tagSelection:
+          semver:
+            constraints: #@ getConstraint("cartographer")
+            prereleases:
+              identifiers: [ "rc" ]
+        assetNames: ["cartographer.yaml"]
+        disableAutoChecksumValidation: true
+  - path: vendir/flux2
+    contents:
+    - path: .
+      githubRelease:
+        slug: fluxcd/flux2
+        tagSelection:
+          semver:
+            constraints: #@ getConstraint("flux2")
+        assetNames: ["install.yaml"]
+        disableAutoChecksumValidation: true
+  - path: vendir/kpack
+    contents:
+    - path: .
+      githubRelease:
+        slug: pivotal/kpack
+        tagSelection:
+          semver:
+            constraints: #@ getConstraint("kpack")
+        assetNames:
+          - #@ "release-*.yaml"
+        disableAutoChecksumValidation: true
+  #! Binaries
+  - path: vendir/binaries
+    contents:
+    - path: yq
+      githubRelease:
+        slug: mikefarah/yq
+        tagSelection:
+          semver:
+            constraints: #@ getConstraint("yq")
+        assetNames:
+        - #@ "yq_" + os + "_" + arch
+        disableAutoChecksumValidation: true
+    - path: ytt
+      githubRelease:
+        slug: vmware-tanzu/carvel-ytt
+        tagSelection:
+          semver:
+            constraints: #@ getConstraint("ytt")
+        assetNames:
+          - #@ "ytt-" + os + "-" + arch
+        disableAutoChecksumValidation: true
+    - path: kapp
+      githubRelease:
+        slug: vmware-tanzu/carvel-kapp
+        tagSelection:
+          semver:
+            constraints: #@ getConstraint("kapp")
+        assetNames:
+        - #@ "kapp-" + os + "-" + arch
+        disableAutoChecksumValidation: true
+    - path: kn
+      githubRelease:
+        slug: knative/client
+        #@ if data.values.vendir.getLatest:
+        latest: true
+        #@ else:
+        tag: #@ "knative-v" + versions["kn"]
+        #@ end
+        assetNames:
+        - #@ "kn-" + os + "-" + arch
+        disableAutoChecksumValidation: true
+    - path: kp
+      githubRelease:
+        slug: vmware-tanzu/kpack-cli
+        tagSelection:
+          semver:
+            constraints: #@ getConstraint("kp")
+        assetNames:
+          - #@ "kp-" + os + "-*"
+        disableAutoChecksumValidation: true
+    - path: kubectl
+      http:
+        url: #@ "https://dl.k8s.io/release/v" + versions["kubectl"] + "/bin/" + os + "/" + arch + "/kubectl"
+  #! TCE
+  - path: vendir/binaries-tce
+    contents:
+    - path: .
+      githubRelease:
+        slug: vmware-tanzu/community-edition
+        tagSelection:
+          semver:
+            constraints: #@ getConstraint("tce")
+        assetNames:
+          - #@ "tce-" + os + "-" + arch + "-v*.tar.gz"
+        disableAutoChecksumValidation: true
+#!        unpackArchive:
+#!          path: #@ "tce-" + os + "-" + arch + "-v*.tar.gz"

--- a/setup/vendir.yml
+++ b/setup/vendir.yml
@@ -1,30 +1,21 @@
 #@ load("@ytt:data", "data")
+#@ load("@ytt:struct", "struct")
+
+#@ def getFixedVersion(key):
+#@   versions = struct.decode(data.values.vendir.versions)
+#@   return versions[key]
+#@ end
 
 #! For more info on setting semver constraints, see:
 #!   https://carvel.dev/vendir/docs/latest/versions
 #!   https://github.com/blang/semver#ranges
-#@ def getConstraint(key):
+#@ def getVersion(key):
 #@   if data.values.vendir.getLatest:
 #@     return ">0.0.0"
 #@   else:
-#@     return versions[key]
+#@     return getFixedVersion(key)
 #@   end
 #@ end
-
-#@ versions = {
-#@ "cert-manager": "1.5.3",
-#@ "secretgen-controller": "0.6.0",
-#@ "cartographer": "0.0.8-rc.7",
-#@ "flux2": "0.24.1",
-#@ "kpack": "0.4.3",
-#@ "yq": "4.16.1",
-#@ "ytt": "0.38.0",
-#@ "kapp": "0.43.0",
-#@ "kn": "1.1.0",
-#@ "tce": "0.9.1",
-#@ "kp": "0.4.2",
-#@ "kubectl": "1.23.1",
-#@ }
 
 #@ os = data.values.vendir.host.os or "darwin"
 #@ arch = data.values.vendir.host.arch or "amd64"
@@ -41,7 +32,7 @@ directories:
         slug: jetstack/cert-manager
         tagSelection:
           semver:
-            constraints: #@ getConstraint("cert-manager")
+            constraints: #@ getVersion("cert-manager")
         assetNames: [ "cert-manager.yaml" ]
         disableAutoChecksumValidation: true
   - path: vendir/secretgen-controller
@@ -51,7 +42,7 @@ directories:
         slug: vmware-tanzu/carvel-secretgen-controller
         tagSelection:
           semver:
-            constraints: #@ getConstraint("secretgen-controller")
+            constraints: #@ getVersion("secretgen-controller")
         assetNames: ["release.yml"]
         disableAutoChecksumValidation: true
   - path: vendir/cartographer
@@ -61,7 +52,7 @@ directories:
         slug: vmware-tanzu/cartographer
         tagSelection:
           semver:
-            constraints: #@ getConstraint("cartographer")
+            constraints: #@ getVersion("cartographer")
             prereleases:
               identifiers: [ "rc" ]
         assetNames: ["cartographer.yaml"]
@@ -73,7 +64,7 @@ directories:
         slug: fluxcd/flux2
         tagSelection:
           semver:
-            constraints: #@ getConstraint("flux2")
+            constraints: #@ getVersion("flux2")
         assetNames: ["install.yaml"]
         disableAutoChecksumValidation: true
   - path: vendir/kpack
@@ -83,7 +74,7 @@ directories:
         slug: pivotal/kpack
         tagSelection:
           semver:
-            constraints: #@ getConstraint("kpack")
+            constraints: #@ getVersion("kpack")
         assetNames:
           - #@ "release-*.yaml"
         disableAutoChecksumValidation: true
@@ -95,7 +86,7 @@ directories:
         slug: mikefarah/yq
         tagSelection:
           semver:
-            constraints: #@ getConstraint("yq")
+            constraints: #@ getVersion("yq")
         assetNames:
         - #@ "yq_" + os + "_" + arch
         disableAutoChecksumValidation: true
@@ -104,7 +95,7 @@ directories:
         slug: vmware-tanzu/carvel-ytt
         tagSelection:
           semver:
-            constraints: #@ getConstraint("ytt")
+            constraints: #@ getVersion("ytt")
         assetNames:
           - #@ "ytt-" + os + "-" + arch
         disableAutoChecksumValidation: true
@@ -113,7 +104,7 @@ directories:
         slug: vmware-tanzu/carvel-kapp
         tagSelection:
           semver:
-            constraints: #@ getConstraint("kapp")
+            constraints: #@ getVersion("kapp")
         assetNames:
         - #@ "kapp-" + os + "-" + arch
         disableAutoChecksumValidation: true
@@ -123,7 +114,7 @@ directories:
         #@ if data.values.vendir.getLatest:
         latest: true
         #@ else:
-        tag: #@ "knative-v" + versions["kn"]
+        tag: #@ "knative-v" + getVersion("kn")
         #@ end
         assetNames:
         - #@ "kn-" + os + "-" + arch
@@ -133,13 +124,13 @@ directories:
         slug: vmware-tanzu/kpack-cli
         tagSelection:
           semver:
-            constraints: #@ getConstraint("kp")
+            constraints: #@ getVersion("kp")
         assetNames:
           - #@ "kp-" + os + "-*"
         disableAutoChecksumValidation: true
     - path: kubectl
       http:
-        url: #@ "https://dl.k8s.io/release/v" + versions["kubectl"] + "/bin/" + os + "/" + arch + "/kubectl"
+        url: #@ "https://dl.k8s.io/release/v" + getFixedVersion("kubectl") + "/bin/" + os + "/" + arch + "/kubectl"
   #! TCE
   - path: vendir/binaries-tce
     contents:
@@ -148,7 +139,7 @@ directories:
         slug: vmware-tanzu/community-edition
         tagSelection:
           semver:
-            constraints: #@ getConstraint("tce")
+            constraints: #@ getVersion("tce")
         assetNames:
           - #@ "tce-" + os + "-" + arch + "-v*.tar.gz"
         disableAutoChecksumValidation: true

--- a/source-to-knative-service/app-operator/supply-chain.yaml
+++ b/source-to-knative-service/app-operator/supply-chain.yaml
@@ -20,7 +20,7 @@ metadata:
   name: supply-chain
 spec:
   selector:
-    app.tanzu.vmware.com/workload-type: web
+    apps.tanzu.vmware.com/workload-type: web
 
   #
   #     source-provider                   fluxcd/GitRepository


### PR DESCRIPTION
Added:
1. Vendir configuration to download:
    -- CLI binaries (ytt, kn, kp, etc...)
    -- Cluster tools that are not part of the TCE community repo (Cartographer, Flux, kpack, etc)
2. Declarative configuration for Cartographer namespace
3.  Declarative configuration for access control (service account, secret, roles, etc... See setup/access-control)
3. setup.sh script that automatically executes `vendir sync`, moves binaries to `./bin`, and uses `ytt | kapp` to apply all of the YAML configuration to the cluster