### PR TITLE
Change cartographer version to 0.1.0 (from 0.1.0-rc.1)

### DIFF
--- a/config-REDACTED.yaml
+++ b/config-REDACTED.yaml
@@ -31,7 +31,7 @@ vendir:
   # getLatest overrides declared versions (disable using getLatest: "")
   getLatest: ""
   versions:
-    cartographer: 0.1.0-rc.1
+    cartographer: 0.1.0
     cert-manager: 1.5.3
     kn: 1.1.0
     kp: 0.4.2


### PR DESCRIPTION
Hit this error running download-dependencies.sh:
```
vendir: Error: Syncing directory 'vendir/cartographer':
  Syncing directory '.' with github release contents:
    Downloading release info:
      Downloading release details from https://api.github.com/repos/vmware-tanzu/cartographer/releases/tags/v0.1.0-rc.1 :
        Expected response status 200, but was '404' (hint: if you are using 'latest: true', there may not be any non-pre-release releases) (body: '{"message":"Not Found","documentation_url":"https://docs.github.com/rest/reference/repos#get-a-release-by-tag-name"}')
```
I could not find v0.1.0-rc1 in  https://api.github.com/repos/vmware-tanzu/cartographer/releases/tags/ but did find v0.1.0.
Assuming rc1 has been promoted to v0.1.0, I edited config-REDACTED.yaml and changed to 0.1.0... 
```
---snip---
  # getLatest overrides declared versions (disable using getLatest: "")
  getLatest: ""
  versions:
    cartographer: 0.1.0    <---CHANGE
---snip---
After this change download-dependencies ran successfully.